### PR TITLE
feat : imageTag 문자열 처리 추가

### DIFF
--- a/src/main/java/com/createver/server/domain/image/service/gallery/ImageGenerationService.java
+++ b/src/main/java/com/createver/server/domain/image/service/gallery/ImageGenerationService.java
@@ -147,7 +147,9 @@ public class ImageGenerationService {
     }
 
     private String getNextImageSize() {
-        return isLargeSizeNext ? "1024x1792" : "1024x1024";
+        String nextSize = isLargeSizeNext ? "1024x1792" : "1024x1024";
+        isLargeSizeNext = !isLargeSizeNext;
+        return nextSize;
     }
 
     private boolean isLargeSizeNext = true;

--- a/src/main/java/com/createver/server/domain/image/service/tag/ImageTagService.java
+++ b/src/main/java/com/createver/server/domain/image/service/tag/ImageTagService.java
@@ -22,9 +22,11 @@ public class ImageTagService {
     @Transactional
     public List<ImageTag> getOrCreateTags(String[] tagNames) {
 
-        Set<String> tagNameSet = new HashSet<>(Arrays.asList(tagNames));
+        Set<String> tagNameSet = Arrays.stream(tagNames)
+                .map(tagName -> tagName.replace(",", "").replace(".", "")) // 쉼표와 마침표 제거
+                .collect(Collectors.toSet());
 
-        List<ImageTag> existingTags = imageTagRepository.findByNameIn(tagNameSet);
+        List<ImageTag> existingTags = new ArrayList<>(imageTagRepository.findByNameIn(tagNameSet));
         Map<String, ImageTag> tagMap = existingTags.stream()
                 .collect(Collectors.toMap(ImageTag::getName, Function.identity()));
 

--- a/src/test/java/com/createver/server/domain/image/service/ImageTagServiceTest.java
+++ b/src/test/java/com/createver/server/domain/image/service/ImageTagServiceTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.*;
 
@@ -75,5 +74,28 @@ class ImageTagServiceTest {
         assertNotNull(result);
         assertFalse(result.isEmpty());
         verify(imageTagRepository).findAll(pageable);
+    }
+
+    @DisplayName("쉼표와 마침표 포함 태그 생성")
+    @Test
+    void getOrCreateTagsWithCommaAndPeriodTest() {
+        // Given
+        String[] tagNames = {"Test,", "Tag.", "Hello,World."};
+        List<ImageTag> existingTags = Collections.emptyList();
+
+        when(imageTagRepository.findByNameIn(anySet())).thenReturn(new ArrayList<>(existingTags));
+        when(imageTagRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        List<ImageTag> tags = imageTagService.getOrCreateTags(tagNames);
+
+        // Then
+        assertNotNull(tags);
+        assertEquals(3, tags.size());
+        assertTrue(tags.stream().anyMatch(tag -> "Test".equals(tag.getName())));
+        assertTrue(tags.stream().anyMatch(tag -> "Tag".equals(tag.getName())));
+        assertTrue(tags.stream().anyMatch(tag -> "HelloWorld".equals(tag.getName())));
+        verify(imageTagRepository).findByNameIn(anySet());
+        verify(imageTagRepository, times(1)).saveAll(anyList());
     }
 }


### PR DESCRIPTION
- ImageTagService 내에서 태그 값을 저장하기 전에 쉼표(,)와 마침표(.)를 제거하는 로직 추가.
- 관련 테스트 케이스 추가
- 이미지 사이즈 결정 로직 조정